### PR TITLE
Make Jelly Drop gooder

### DIFF
--- a/MinigamesTheSpire/src/main/resources/minigamesResources/loc/eng/eventStrings.json
+++ b/MinigamesTheSpire/src/main/resources/minigamesResources/loc/eng/eventStrings.json
@@ -191,7 +191,7 @@
       "Ouch! NL NL You barely got through the jelly mayhem. NL You are relieved, but return empty handed."
     ],
     "OPTIONS": [
-      "[Start] Play for #b80 seconds.",
+      "[Start] Play for #b90 seconds.",
       "[Collect] #gObtain #gRewards.",
       "[Leave]"
     ]


### PR DESCRIPTION
Made Jelly Drop easier so I can get 500 points all the time. [/s]


Gameplay changes
- Time limit: 80 -> 90
  - Now the timer starts after you can control the first jellies.
- Difference between act was removed. (It didn't make sense with the hi-score feature)
- Gold rewards changed to 25/25/25.
- The probability of big jelly now depends on remaining time instead of the number of jellies dropped. (to reduce the variance between fast and slow people)
- The delay when you can control the next jelly after putting the previous one was reduced.

Other changes
- Jellies outside of the game screen are no longer visible. (until game over)
- Sound effects are louder.
